### PR TITLE
Loading accounts and API depending on environnements variables

### DIFF
--- a/Week2/ballot/hardhat.config.ts
+++ b/Week2/ballot/hardhat.config.ts
@@ -1,15 +1,33 @@
 import { task, type HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-toolbox-viem";
-require("dotenv").config();
+import { load_account_from_env, load_api_sepolia } from "./utils/load_env";
+import { HDAccountsUserConfig } from "hardhat/types";
 
-const deployerKey = process.env.SEPOLIA_PRIVATE_KEY || "";
+// Loading either the hd account or the private key
+const [acc, privateData] = load_account_from_env();
+let accounts;
+if (acc.source == "hd") {
+  const hd: HDAccountsUserConfig = {
+    mnemonic: privateData,
+    path: "m/44'/60'/0'/0",
+    initialIndex: 0,
+    count: 20,
+    passphrase: "",
+  };
+  accounts = hd;
+} else {
+  // if (acc.source == 'privateKey')
+  accounts = [privateData];
+}
 
+// Hardhat config
 const config: HardhatUserConfig = {
   solidity: "0.8.24",
   networks: {
+    hardhat: {},
     sepolia: {
-      url: process.env.ALCHEMY_API_KEY,
-      accounts: [process.env.SEPOLIA_PRIVATE_KEY || ""],
+      url: load_api_sepolia().url,
+      accounts,
     },
   },
 };

--- a/Week2/ballot/scripts/CastVote.ts
+++ b/Week2/ballot/scripts/CastVote.ts
@@ -9,11 +9,10 @@ import {
 import { privateKeyToAccount } from "viem/accounts";
 import { abi, bytecode } from "../artifacts/contracts/Ballot.sol/Ballot.json";
 import { sepolia } from "viem/chains";
-import * as dotenv from "dotenv";
-dotenv.config();
+import { load_account_from_env, load_api_sepolia } from "../utils/load_env";
 
-const providerApiKey = process.env.INFURA_API_KEY || "";
-const deployerPrivateKey = process.env.PRIVATE_KEY || "";
+const { url: apiUrl } = load_api_sepolia();
+const [account] = load_account_from_env();
 
 async function main() {
   const parameters = process.argv.slice(2);
@@ -28,7 +27,7 @@ async function main() {
   console.log("Proposal selected: ");
   const publicClient = createPublicClient({
     chain: sepolia,
-    transport: http(`https://sepolia.infura.io/v3/${providerApiKey}`),
+    transport: http(apiUrl),
   });
   const proposal = (await publicClient.readContract({
     address: contractAddress,
@@ -40,11 +39,10 @@ async function main() {
   console.log("Voting to proposal", name);
   console.log("Confirm? (Y/n)");
   const stdin = process.stdin.resume();
-  const account = privateKeyToAccount(`0x${deployerPrivateKey}`);
   const voter = createWalletClient({
-    account,
+    account: account,
     chain: sepolia,
-    transport: http(`https://sepolia.infura.io/v3/${providerApiKey}`),
+    transport: http(apiUrl),
   });
   stdin.addListener("data", async function (d) {
     if (d.toString().trim().toLowerCase() != "n") {

--- a/Week2/ballot/scripts/DelegateVote.ts
+++ b/Week2/ballot/scripts/DelegateVote.ts
@@ -1,66 +1,63 @@
 import {
-    createPublicClient,
-    http,
-    createWalletClient,
-    formatEther,
-  } from "viem";
-  import { sepolia } from "viem/chains";
-  import { privateKeyToAccount } from "viem/accounts";
-  import { abi } from "../artifacts/contracts/Ballot.sol/Ballot.json";
-  require("dotenv").config();
-  
-  const contractAddress = "0x878357c449a6aa94a6b3956f58b430d9ed84ebeb";
-  const providerApiWithKey = process.env.INFURA_API || "";
-  const deployerPrivateKey = process.env.SEPOLIA_PRIVATE_KEY || "";
-  
-  async function main() {
-    const parameters = process.argv.slice(2);
-    if (!parameters || parameters.length < 2)
-      throw new Error("Parameters not provided");
-    const contractAddress = parameters[0] as `0x${string}`;
-    
-    if (!contractAddress) throw new Error("Contract address not provided");
-    if (!/^0x[a-fA-F0-9]{40}$/.test(contractAddress))
-      throw new Error("Invalid contract address");
-    const delegateAddress = parameters[1] as `0x${string}`;
-    const publicClient = createPublicClient({
-      chain: sepolia,
-      transport: http(`${providerApiWithKey}`),
-    });
-    const blockNumber = await publicClient.getBlockNumber();
-    console.log("Last block number:", blockNumber);
-  
-    const account = privateKeyToAccount(`0x${deployerPrivateKey}`);
-    const walletClient = createWalletClient({
-      account,
-      chain: sepolia,
-      transport: http(`${providerApiWithKey}`),
-    });
-    console.log("Deployer address:", walletClient.account.address);
-    const balance = await publicClient.getBalance({
-      address: walletClient.account.address,
-    });
-    console.log(
-      "Deployer balance:",
-      formatEther(balance),
-      walletClient.chain.nativeCurrency.symbol
-    );
-  
-    const hash = await walletClient.writeContract({
-      address: contractAddress,
-      abi,
-      functionName: "delegate",
-      account: account,
-      args: [delegateAddress],
-    });
-    console.log("Transaction hash:", hash);
-    console.log("Waiting for confirmations...");
-      const reciept = await publicClient.waitForTransactionReceipt({ hash });
-      console.log("Transaction Confirmed");
-  }
-  
-  main().catch((error) => {
-    console.error(error);
-    process.exitCode = 1;
+  createPublicClient,
+  http,
+  createWalletClient,
+  formatEther,
+} from "viem";
+import { sepolia } from "viem/chains";
+import { privateKeyToAccount } from "viem/accounts";
+import { abi } from "../artifacts/contracts/Ballot.sol/Ballot.json";
+import { load_account_from_env, load_api_sepolia } from "../utils/load_env";
+
+const { url: apiUrl } = load_api_sepolia();
+const [deployerAccount] = load_account_from_env();
+
+async function main() {
+  const parameters = process.argv.slice(2);
+  if (!parameters || parameters.length < 2)
+    throw new Error("Parameters not provided");
+  const contractAddress = parameters[0] as `0x${string}`;
+
+  if (!contractAddress) throw new Error("Contract address not provided");
+  if (!/^0x[a-fA-F0-9]{40}$/.test(contractAddress))
+    throw new Error("Invalid contract address");
+  const delegateAddress = parameters[1] as `0x${string}`;
+  const publicClient = createPublicClient({
+    chain: sepolia,
+    transport: http(apiUrl),
   });
-  
+  const blockNumber = await publicClient.getBlockNumber();
+  console.log("Last block number:", blockNumber);
+
+  const walletClient = createWalletClient({
+    account: deployerAccount,
+    chain: sepolia,
+    transport: http(apiUrl),
+  });
+  console.log("Deployer address:", walletClient.account.address);
+  const balance = await publicClient.getBalance({
+    address: walletClient.account.address,
+  });
+  console.log(
+    "Deployer balance:",
+    formatEther(balance),
+    walletClient.chain.nativeCurrency.symbol
+  );
+
+  const hash = await walletClient.writeContract({
+    address: contractAddress,
+    abi,
+    functionName: "delegate",
+    account: account,
+    args: [delegateAddress],
+  });
+  console.log("Transaction hash:", hash);
+  console.log("Waiting for confirmations...");
+  const reciept = await publicClient.waitForTransactionReceipt({ hash });
+  console.log("Transaction Confirmed");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/Week2/ballot/scripts/DeployWithViem.ts
+++ b/Week2/ballot/scripts/DeployWithViem.ts
@@ -9,13 +9,10 @@ import {
 import { privateKeyToAccount } from "viem/accounts";
 import { abi, bytecode } from "../artifacts/contracts/Ballot.sol/Ballot.json";
 import { sepolia } from "viem/chains";
-import * as dotenv from "dotenv";
-dotenv.config();
+import { load_account_from_env, load_api_sepolia } from "../utils/load_env";
 
-
-
-const providerApiKey = process.env.INFURA_API_KEY || "";
-const deployerPrivateKey = process.env.PRIVATE_KEY || "";
+const { url: apiUrl } = load_api_sepolia();
+const [deployerAccount] = load_account_from_env();
 
 async function main() {
   const proposals = process.argv.slice(2);
@@ -23,16 +20,15 @@ async function main() {
     throw new Error("Proposals not provided");
   const publicClient = createPublicClient({
     chain: sepolia,
-    transport: http(`https://sepolia.infura.io/v3/${providerApiKey}`),
+    transport: http(apiUrl),
   });
   const blockNumber = await publicClient.getBlockNumber();
   console.log("Last block number:", blockNumber);
 
-  const account = privateKeyToAccount(`0x${deployerPrivateKey}`);
   const deployer = createWalletClient({
-    account,
+    account: deployerAccount,
     chain: sepolia,
-    transport: http(`https://sepolia.infura.io/v3/${providerApiKey}`),
+    transport: http(apiUrl),
   });
   console.log("Deployer address:", deployer.account.address);
   const balance = await publicClient.getBalance({

--- a/Week2/ballot/scripts/GiveVotingRight.ts
+++ b/Week2/ballot/scripts/GiveVotingRight.ts
@@ -1,40 +1,38 @@
 import {
-    createPublicClient,
-    http,
-    createWalletClient,
-    formatEther,
-  } from "viem";
-  import { sepolia } from "viem/chains";
-  import { privateKeyToAccount } from "viem/accounts";
-  import { abi } from "../artifacts/contracts/Ballot.sol/Ballot.json";
-  require("dotenv").config();
-  
-  const contractAddress = "0x878357c449a6aa94a6b3956f58b430d9ed84ebeb";
-  const providerApiWithKey = process.env.INFURA_API|| "";
-  const deployerPrivateKey = process.env.SEPOLIA_PRIVATE_KEY || "";
+  createPublicClient,
+  http,
+  createWalletClient,
+  formatEther,
+} from "viem";
+import { sepolia } from "viem/chains";
+import { privateKeyToAccount, mnemonicToAccount } from "viem/accounts";
+import { abi } from "../artifacts/contracts/Ballot.sol/Ballot.json";
+import { load_account_from_env, load_api_sepolia } from "../utils/load_env";
 
-  async function main() {
-    const parameters = process.argv.slice(2);
+const { url: apiUrl } = load_api_sepolia();
+const [account] = load_account_from_env();
+
+async function main() {
+  const parameters = process.argv.slice(2);
   if (!parameters || parameters.length < 2)
     throw new Error("Parameters not provided");
   const contractAddress = parameters[0] as `0x${string}`;
-  
+
   if (!contractAddress) throw new Error("Contract address not provided");
   if (!/^0x[a-fA-F0-9]{40}$/.test(contractAddress))
     throw new Error("Invalid contract address");
   const voterAddress = parameters[1] as `0x${string}`;
   const publicClient = createPublicClient({
     chain: sepolia,
-    transport: http(`${providerApiWithKey}`),
+    transport: http(apiUrl),
   });
   const blockNumber = await publicClient.getBlockNumber();
   console.log("Last block number:", blockNumber);
 
-  const account = privateKeyToAccount(`0x${deployerPrivateKey}`);
   const walletClient = createWalletClient({
-    account,
+    account: account,
     chain: sepolia,
-    transport: http(`${providerApiWithKey}`),
+    transport: http(apiUrl),
   });
   console.log("Deployer address:", walletClient.account.address);
   const balance = await publicClient.getBalance({
@@ -55,12 +53,11 @@ import {
   });
   console.log("Transaction hash:", hash);
   console.log("Waiting for confirmations...");
-    const reciept = await publicClient.waitForTransactionReceipt({ hash });
-    console.log("Transaction Confirmed");
+  const reciept = await publicClient.waitForTransactionReceipt({ hash });
+  console.log("Transaction Confirmed");
+}
 
-  }
-
-  main().catch((error) => {
-    console.error(error);
-    process.exitCode = 1;
-  });
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/Week2/ballot/utils/load_env.ts
+++ b/Week2/ballot/utils/load_env.ts
@@ -8,13 +8,16 @@ import {
   HDAccount,
 } from "viem/accounts";
 
-export function load_account_from_env(): PrivateKeyAccount | HDAccount {
+export function load_account_from_env(): [
+  PrivateKeyAccount | HDAccount,
+  string
+] {
   const mnemonic = process.env.MNEMONIC;
   const privateKey = process.env.PRIVATE_KEY;
   if (mnemonic) {
-    return mnemonicToAccount(mnemonic, { accountIndex: 0 });
+    return [mnemonicToAccount(mnemonic, { accountIndex: 0 }), mnemonic];
   } else if (privateKey) {
-    return privateKeyToAccount(`0x${privateKey}`);
+    return [privateKeyToAccount(`0x${privateKey}`), privateKey];
   } else {
     throw new Error(
       "Couldn't find either MNEMONIC or PRIVATE_KEY in your .env"
@@ -39,7 +42,7 @@ export function load_api_sepolia(): API {
   } else if (infura) {
     return {
       apiKey: infura,
-      url: `https://sepolia.rpc.grove.city/v1/${infura}`,
+      url: `https://sepolia.infura.io/v3/${infura}`,
     };
   }
 

--- a/Week2/ballot/utils/load_env.ts
+++ b/Week2/ballot/utils/load_env.ts
@@ -1,0 +1,50 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+
+import {
+  mnemonicToAccount,
+  privateKeyToAccount,
+  PrivateKeyAccount,
+  HDAccount,
+} from "viem/accounts";
+
+export function load_account_from_env(): PrivateKeyAccount | HDAccount {
+  const mnemonic = process.env.MNEMONIC;
+  const privateKey = process.env.PRIVATE_KEY;
+  if (mnemonic) {
+    return mnemonicToAccount(mnemonic, { accountIndex: 0 });
+  } else if (privateKey) {
+    return privateKeyToAccount(`0x${privateKey}`);
+  } else {
+    throw new Error(
+      "Couldn't find either MNEMONIC or PRIVATE_KEY in your .env"
+    );
+  }
+}
+
+export type API = {
+  apiKey: string | null;
+  url: string;
+};
+
+export function load_api_sepolia(): API {
+  const alchemy = process.env.ALCHEMY_API_KEY;
+  const infura = process.env.INFURA_API_KEY;
+
+  if (alchemy) {
+    return {
+      apiKey: alchemy,
+      url: `https://eth-sepolia.g.alchemy.com/v2/${alchemy}`,
+    };
+  } else if (infura) {
+    return {
+      apiKey: infura,
+      url: `https://sepolia.rpc.grove.city/v1/${infura}`,
+    };
+  }
+
+  return {
+    apiKey: null,
+    url: "https://ethereum-sepolia-rpc.publicnode.com",
+  };
+}


### PR DESCRIPTION
This ensure that we can use any API and type of accounts (mnemonic or private key). 
This is a simple solution: it doesn't do a fallback on API that is congested for instance.
The order cannot be defined by the .env, it uses mnemonic then private key and Alchemy then infuria. 

You need to comment in your .env to be able to control the one that is being used.


Github as some issue showing the specific changes: it is only related to the loaded account and url, see the utils folder.